### PR TITLE
release: @echecs/koya@3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.0.2] - 2026-04-17
+
+### Fixed
+
+- Added top-level `types` field to `package.json` for TypeScript configs that
+  don't resolve types through `exports` conditions.
+
 ## 3.0.1 — 2026-04-09
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -73,5 +73,5 @@
   },
   "sideEffects": false,
   "type": "module",
-  "version": "3.0.1"
+  "version": "3.0.2"
 }


### PR DESCRIPTION
bumps to 3.0.2. the actual fix (`types` field) is already on `main`. this PR adds the version bump and changelog entry so CI can publish.