### PR TITLE
chore: add @echecs/tournament as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
     "url": "https://github.com/echecsjs/koya/issues"
   },
   "description": "Koya tiebreak system for round-robin chess tournaments following FIDE rules. Zero dependencies.",
+  "peerDependencies": {
+    "@echecs/tournament": "^2.0.0"
+  },
   "devDependencies": {
     "@echecs/tournament": "^2.1.2",
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
moves `@echecs/tournament` to `peerDependencies` to ensure type identity with the consumer's copy. keeps it in `devDependencies` for local development.

closes #23