### PR TITLE
chore: align .gitignore with canonical template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,16 @@
+# Output
+/dist/
+
+# Node
+/node_modules/
+
+# Tests
 coverage/
-dist/
-node_modules/
+
+# Documentation
+docs/api/*
+!docs/api/.gitkeep
+
+# Agent planning artifacts
+.superpowers/
+docs/superpowers/


### PR DESCRIPTION
aligns .gitignore to the canonical trf template