### PR TITLE
chore: update homepage to echecs.dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "README.md",
     "CHANGELOG.md"
   ],
-  "homepage": "https://github.com/echecsjs/koya#readme",
+  "homepage": "https://koya.echecs.dev",
   "keywords": [
     "chess",
     "fide",


### PR DESCRIPTION
points homepage to the docs site instead of the github repo