### PR TITLE
feat!: adapt to @echecs/tournament v3 types

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   },
   "description": "Koya tiebreak system for round-robin chess tournaments following FIDE rules. Zero dependencies.",
   "peerDependencies": {
-    "@echecs/tournament": "^2.0.0"
+    "@echecs/tournament": "^3.0.0"
   },
   "devDependencies": {
-    "@echecs/tournament": "^2.1.2",
+    "@echecs/tournament": "^3.1.0",
     "@eslint/js": "^10.0.1",
     "@typescript-eslint/parser": "^8.57.0",
     "@vitest/coverage-v8": "^4.1.0",
@@ -80,5 +80,5 @@
   },
   "sideEffects": false,
   "type": "module",
-  "version": "3.0.3"
+  "version": "4.0.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@echecs/tournament':
-        specifier: ^2.1.2
-        version: 2.1.2
+        specifier: ^3.1.0
+        version: 3.1.0
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.3.0)
@@ -107,9 +107,9 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@echecs/tournament@2.1.2':
-    resolution: {integrity: sha512-DYq8Nbc1Dq15ZpQMKWziGmfyxd4RC0jIgWsbVRLM6/q+sPKPjSPxiBtRC8+u5gPr0lKaK5eoZKs295I/W60akA==}
-    engines: {node: '>=20'}
+  '@echecs/tournament@3.1.0':
+    resolution: {integrity: sha512-eXc0BMjpimolwpcPnuzEClyFZ90TnN2nLEJLJ7UCr4oFCstjI2lUbABnLE7HsKUYg+j7QadgtTR2J+wcflDlwg==}
+    engines: {node: '>=22'}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -1817,7 +1817,7 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@echecs/tournament@2.1.2': {}
+  '@echecs/tournament@3.1.0': {}
 
   '@emnapi/core@1.10.0':
     dependencies:

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -2,103 +2,74 @@ import { describe, expect, it } from 'vitest';
 
 import { koya } from '../index.js';
 
-import type { Game } from '../types.js';
+import type { CompletedRound, Player } from '@echecs/tournament';
 
-// 4 players, 3 rounds:
-// Round 1: A(W) 1-0 B, C(W) 0-1 D
-// Round 2: A(W) 0.5-0.5 D, C(W) 0-1 B
-// Round 3: A(W) 1-0 C, D(W) 1-0 B
-// Scores: A=2.5, D=2.5, B=1, C=0
-// games.length=3, threshold=1.5
-// Players with >= 1.5 points: A(2.5), D(2.5)
+const PLAYERS: Player[] = [
+  { id: 'A', points: 2.5, rank: 1 },
+  { id: 'B', points: 1, rank: 3 },
+  { id: 'C', points: 0, rank: 4 },
+  { id: 'D', points: 2.5, rank: 2 },
+];
 
-const GAMES: Game[][] = [
-  [
-    { black: 'B', result: 1, white: 'A' },
-    { black: 'D', result: 0, white: 'C' },
-  ],
-  [
-    { black: 'D', result: 0.5, white: 'A' },
-    { black: 'B', result: 0, white: 'C' },
-  ],
-  [
-    { black: 'C', result: 1, white: 'A' },
-    { black: 'B', result: 1, white: 'D' },
-  ],
+const ROUNDS: CompletedRound[] = [
+  {
+    byes: [],
+    games: [
+      { black: 'B', result: 'white', white: 'A' },
+      { black: 'D', result: 'black', white: 'C' },
+    ],
+  },
+  {
+    byes: [],
+    games: [
+      { black: 'D', result: 'draw', white: 'A' },
+      { black: 'B', result: 'black', white: 'C' },
+    ],
+  },
+  {
+    byes: [],
+    games: [
+      { black: 'C', result: 'white', white: 'A' },
+      { black: 'B', result: 'white', white: 'D' },
+    ],
+  },
 ];
 
 describe('koya', () => {
   it('returns points scored against opponents with >= 50% of max score', () => {
-    // threshold = 3/2 = 1.5
-    // A's opponents: B(1) < 1.5, D(2.5) >= 1.5, C(0) < 1.5
-    // Only D qualifies; A drew D → 0.5
-    expect(koya('A', GAMES)).toBe(0.5);
+    expect(koya('A', ROUNDS, PLAYERS)).toBe(0.5);
   });
 
   it('handles player with no games', () => {
-    expect(koya('A', [])).toBe(0);
+    expect(koya('A', [], PLAYERS)).toBe(0);
   });
 
   it('returns 0 when no opponent meets the threshold', () => {
-    // B's opponents: A(2.5)>=1.5, C(0)<1.5, D(2.5)>=1.5
-    // B scored 0 vs A, 1 vs C (C<threshold), 0 vs D → 0
-    expect(koya('B', GAMES)).toBe(0);
+    expect(koya('B', ROUNDS, PLAYERS)).toBe(0);
   });
 
-  it('excludes bye games from koya sum but counts bye points toward threshold', () => {
-    // 3 players, 3 rounds (odd count — one bye per round):
-    // Round 1: A(W) 1-0 B, C bye (1 point)
-    // Round 2: B(W) 0-1 C, A bye (1 point)
-    // Round 3: A(W) 1-0 C, B bye (1 point)
-    // Scores: A=3 (1+1bye+1), B=1 (0+0+1bye), C=1 (1bye+1+0) [corrected below]
-    //
-    // Actually let's be precise with the result field for byes.
-    // A bye where player X gets 1 point: { white: 'X', black: 'X', result: 1 }
-    // because result is from white's perspective, and white===black===X → X gets 1.
-    //
-    // Round 1: A beats B (result=1), C gets a bye (result=1)
-    // Round 2: C beats B (result=0, B is white so B gets 0), A gets a bye (result=1)
-    // Round 3: A beats C (result=1), B gets a bye (result=1)
-    //
-    // Scores: A = 1(vs B) + 1(bye) + 1(vs C) = 3
-    //         B = 0(vs A) + 0(vs C) + 1(bye) = 1
-    //         C = 1(bye) + 1(vs B) + 0(vs A) = 2
-    //
-    // threshold = 3/2 = 1.5
-    // Opponents above threshold: A(3) ≥ 1.5, C(2) ≥ 1.5, B(1) < 1.5
-    //
-    // koya('A') — opponents: B(1)<1.5, C(2)>=1.5
-    //   A vs C: round 3, A(W) 1-0 C → 1 point
-    //   = 1
-    //
-    // koya('C') — opponents: B(1)<1.5, A(3)>=1.5
-    //   C vs A: round 3, A(W) 1-0 C → C gets 0
-    //   = 0
-    //
-    // koya('B') — opponents: A(3)>=1.5, C(2)>=1.5
-    //   B vs A: round 1, A(W) 1-0 B → B gets 0
-    //   B vs C: round 2, B(W) 0-1 C → B gets 0
-    //   = 0
-
-    const gamesWithByes: Game[][] = [
-      [
-        { black: 'B', result: 1, white: 'A' },
-        { black: 'C', result: 1, white: 'C' }, // C bye
-      ],
-      [
-        { black: 'C', result: 0, white: 'B' },
-        { black: 'A', result: 1, white: 'A' }, // A bye
-      ],
-      [
-        { black: 'C', result: 1, white: 'A' },
-        { black: 'B', result: 1, white: 'B' }, // B bye
-      ],
+  it('counts bye points toward threshold via Player.points', () => {
+    const players: Player[] = [
+      { id: 'A', points: 3, rank: 1 },
+      { id: 'B', points: 1, rank: 3 },
+      { id: 'C', points: 2, rank: 2 },
     ];
-
-    // C's bye pushes their score to 2 (above 1.5 threshold)
-    // Without bye points, C would only have 1 (below threshold)
-    expect(koya('A', gamesWithByes)).toBe(1);
-    expect(koya('C', gamesWithByes)).toBe(0);
-    expect(koya('B', gamesWithByes)).toBe(0);
+    const rounds: CompletedRound[] = [
+      {
+        byes: [{ kind: 'pairing', player: 'C' }],
+        games: [{ black: 'B', result: 'white', white: 'A' }],
+      },
+      {
+        byes: [{ kind: 'pairing', player: 'A' }],
+        games: [{ black: 'C', result: 'black', white: 'B' }],
+      },
+      {
+        byes: [{ kind: 'pairing', player: 'B' }],
+        games: [{ black: 'C', result: 'white', white: 'A' }],
+      },
+    ];
+    expect(koya('A', rounds, players)).toBe(1);
+    expect(koya('C', rounds, players)).toBe(0);
+    expect(koya('B', rounds, players)).toBe(0);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,24 @@
-import { gamesForPlayer, opponents, score } from './utilities.js';
+import { gamesForPlayer, opponents, scoreFor } from './utilities.js';
 
-import type { Game } from './types.js';
+import type { CompletedRound, Player } from '@echecs/tournament';
 
-function koya(player: string, games: Game[][]): number {
-  const threshold = games.length / 2;
+function koya(
+  player: string,
+  rounds: CompletedRound[],
+  players: Player[],
+): number {
+  const threshold = rounds.length / 2;
   let sum = 0;
-  for (const opp of opponents(player, games)) {
-    const oppScore = score(opp, games);
-    if (oppScore >= threshold) {
-      const gamesBetween = gamesForPlayer(player, games).filter(
-        (g) => g.black !== g.white && (g.white === opp || g.black === opp),
-      );
-      for (const g of gamesBetween) {
-        sum += g.white === player ? g.result : 1 - g.result;
-      }
+  for (const opp of opponents(player, rounds)) {
+    const opponent = players.find((p) => p.id === opp);
+    if (opponent === undefined || opponent.points < threshold) {
+      continue;
+    }
+    const gamesBetween = gamesForPlayer(player, rounds).filter(
+      (g) => g.white === opp || g.black === opp,
+    );
+    for (const g of gamesBetween) {
+      sum += scoreFor(player, g);
     }
   }
   return sum;
@@ -21,4 +26,10 @@ function koya(player: string, games: Game[][]): number {
 
 export { koya, koya as tiebreak };
 
-export type { Game, GameKind, Player, Result } from './types.js';
+export type {
+  Bye,
+  CompletedRound,
+  Game,
+  Pairing,
+  Player,
+} from '@echecs/tournament';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,1 +1,0 @@
-export type { Game, GameKind, Player, Result } from '@echecs/tournament';

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,21 +1,28 @@
-import type { Game } from './types.js';
+import type { CompletedRound, Game } from '@echecs/tournament';
 
-function gamesForPlayer(player: string, games: Game[][]): Game[] {
-  return games.flat().filter((g) => g.white === player || g.black === player);
+function gamesForPlayer(player: string, rounds: CompletedRound[]): Game[] {
+  return rounds
+    .flatMap((r) => r.games)
+    .filter((g) => g.white === player || g.black === player);
 }
 
-function opponents(player: string, games: Game[][]): string[] {
-  return gamesForPlayer(player, games)
-    .filter((g) => g.black !== g.white)
-    .map((g) => (g.white === player ? g.black : g.white));
+function opponents(player: string, rounds: CompletedRound[]): string[] {
+  return gamesForPlayer(player, rounds).map((g) =>
+    g.white === player ? g.black : g.white,
+  );
 }
 
-function score(player: string, games: Game[][]): number {
-  let sum = 0;
-  for (const g of gamesForPlayer(player, games)) {
-    sum += g.white === player ? g.result : 1 - g.result;
+function scoreFor(player: string, game: Game): number {
+  if (game.result === 'draw') {
+    return 0.5;
   }
-  return sum;
+  if (game.result === 'none') {
+    return 0;
+  }
+  return (game.result === 'white' && game.white === player) ||
+    (game.result === 'black' && game.black === player)
+    ? 1
+    : 0;
 }
 
-export { gamesForPlayer, opponents, score };
+export { gamesForPlayer, opponents, scoreFor };


### PR DESCRIPTION
## Summary

- function signature changed from `(player, Game[][])` to `(player, CompletedRound[], Player[])` to match `@echecs/tournament` v3's `Tiebreak` type
- opponent score threshold now reads `Player.points` instead of recomputing from games — bye points count toward threshold naturally
- `Game.result` is now a string literal — added `scoreFor` conversion utility
- peer dependency bumped from `@echecs/tournament@^2.0.0` to `@echecs/tournament@^3.0.0`
- `types.ts` deleted — `GameKind`/`Result` re-exports removed

**breaking change** — bumps to v4.0.0