### PR TITLE
docs: fix outdated tiebreak signature in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,11 @@ pnpm lint && pnpm test && pnpm build
 All tiebreak functions consumed by `@echecs/tournament` must conform to:
 
 ```typescript
-(playerId: string, games: Game[], players: Map<string, Player>) => number;
+type Tiebreak = (
+  player: string,
+  rounds: CompletedRound[],
+  players: Player[],
+) => number;
 ```
 
 ---


### PR DESCRIPTION
the documented signature was wrong — used `Game[]` and `Map<string, Player>` instead of the actual `CompletedRound[]` and `Player[]`.